### PR TITLE
run project with docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:18.04
+
+COPY install-ubuntu.sh .
+COPY install_ipopt.sh .
+RUN apt-get update
+RUN apt-get install sudo git libuv1-dev libssl-dev \
+    gcc g++ cmake make wget unzip gfortran htop zlib1g-dev -y
+RUN sh install-ubuntu.sh
+RUN wget https://www.coin-or.org/download/source/Ipopt/Ipopt-3.12.7.zip && \
+     unzip Ipopt-3.12.7.zip && \
+     rm Ipopt-3.12.7.zip
+RUN sh install_ipopt.sh Ipopt-3.12.7  
+RUN apt-get install gcc-6 g++-6 cppad -y
+# To Compile project remember use Gcc 6
+# cmake -DCMAKE_C_COMPILER="/usr/bin/gcc-6" -DCMAKE_CXX_COMPILER="/usr/bin/g++-6" .. && make

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ Self-Driving Car Engineer Nanodegree Program
 3. Compile: `cmake .. && make`
 4. Run it: `./mpc`.
 
+## Build with Docker-Compose
+The docker-compose can run the project into a container
+and exposes the port required by the simulator to run.
+
+1. Clone this repo.
+2. Build image: `docker-compose build`
+3. Run Container: `docker-compose up`
+4. On code changes repeat steps 2 and 3.
+
 ## Tips
 
 1. It's recommended to test the MPC on basic examples to see if your implementation behaves as desired. One possible example

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.2"
+services:
+  mpc:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "4567:4567"
+    volumes:
+      - type: bind
+        source: ./
+        target: /mpc
+
+    command: bash -c "mkdir -p /mpc/build &&
+                      cd /mpc/build && 
+                      cmake -DCMAKE_C_COMPILER="/usr/bin/gcc-6" -DCMAKE_CXX_COMPILER="/usr/bin/g++-6" .. && make && ./mpc"
+
+volumes:
+  .:


### PR DESCRIPTION
With this change the project can be run into a container that exposes the port 4567 such that the simulator can send and receive info form the container. This has all dependencies needed to run the project with two commands.