### PR TITLE
Fix mumps errors by updating formula to use new deps.

### DIFF
--- a/mumps.rb
+++ b/mumps.rb
@@ -32,10 +32,10 @@ class Mumps < Formula
 
   bottle :disable, "needs to be rebuilt with latest open-mpi"
 
-  depends_on :mpi => [:cc, :cxx, :f90, :recommended]
+  depends_on "open-mpi" => [:cc, :cxx, :f90, :recommended]
   depends_on "openblas" => OS.mac? ? :optional : :recommended
   depends_on "veclibfort" if build.without?("openblas") && OS.mac?
-  depends_on :fortran
+  depends_on "gcc"
 
   if build.with? "mpi"
     if OS.mac?
@@ -55,6 +55,7 @@ class Mumps < Formula
   end
 
   def install
+    set_fortran_compiler_linker
     make_args = ["RANLIB=echo"]
     if OS.mac?
       # Building dylibs with mpif90 causes segfaults on 10.8 and 10.10. Use gfortran.
@@ -190,19 +191,24 @@ class Mumps < Formula
   end
 
   def caveats
-    s = <<-EOS.undent
+    s = <<~EOS
       MUMPS was built with shared libraries. If required,
       static libraries are available in
         #{opt_libexec}/lib
     EOS
     if build.without? "mpi"
-      s += <<-EOS.undent
+      s += <<~EOS
       You built a sequential MUMPS library.
       Please add #{libexec}/include to the include path
       when building software that depends on MUMPS.
       EOS
     end
     s
+  end
+
+  def set_fortran_compiler_linker
+    ENV["FC"] ||= "gfortran"
+    ENV["FL"] ||= "gfortran"
   end
 
   test do


### PR DESCRIPTION

Fixes #24 
* Basically following the error messages that homebrew emitted, first to
  use open-mpi and then to use gcc because that is what installs
  fortran. The method set_fortran_compiler_and_linker will provide the
  default value gfortran for FC and FL if it is not set.

* Ruby new EOS undent syntax is <<~
  See: https://github.com/puma/homebrew-puma/issues/5