### PR TITLE
fix include order

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,3 +1,4 @@
+#include "json.hpp"
 #include <math.h>
 #include <uWS/uWS.h>
 #include <chrono>
@@ -7,7 +8,6 @@
 #include "Eigen-3.3/Eigen/Core"
 #include "Eigen-3.3/Eigen/QR"
 #include "MPC.h"
-#include "json.hpp"
 
 // for convenience
 using json = nlohmann::json;


### PR DESCRIPTION
on ubuntu 16.04 with gcc-7 I got this error until I switched include order:

[ 33%] Building CXX object CMakeFiles/mpc.dir/src/main.cpp.o
In file included from /home/tkramer/projects/CarND-MPC-Project/src/main.cpp:10:0:
/home/tkramer/projects/CarND-MPC-Project/src/json.hpp: In function ‘bool nlohmann::operator<(nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::const_reference, nlohmann::basic_json<ObjectType, ArrayType, StringType, BooleanType, NumberIntegerType, NumberUnsignedType, NumberFloatType, AllocatorType, JSONSerializer>::const_reference)’:
/home/tkramer/projects/CarND-MPC-Project/src/json.hpp:6057:62: error: wrong number of template arguments (1, should be 2)
                     return *lhs.m_value.array < *rhs.m_value.array;
                                                              ^~~~~
