### PR TITLE
Hotfix

### DIFF
--- a/scotch.rb
+++ b/scotch.rb
@@ -1,3 +1,27 @@
+# Script obtained from the https://github.com/Homebrew/homebrew-science repository
+
+'''
+Copyright 2009-2016 Homebrew contributors.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
 class Scotch < Formula
     desc "Graph and mesh partitioning, clustering, and sparse matrix ordering"
     homepage "https://gforge.inria.fr/projects/scotch"

--- a/scotch.rb
+++ b/scotch.rb
@@ -1,0 +1,70 @@
+class Scotch < Formula
+    desc "Graph and mesh partitioning, clustering, and sparse matrix ordering"
+    homepage "https://gforge.inria.fr/projects/scotch"
+    url "https://gforge.inria.fr/frs/download.php/file/34618/scotch_6.0.4.tar.gz"
+    sha256 "f53f4d71a8345ba15e2dd4e102a35fd83915abf50ea73e1bf6efe1bc2b4220c7"
+    
+    option "without-test", "skip build-time tests (not recommended)"
+    
+    depends_on "bzip2" unless OS.mac?
+    depends_on "open-mpi"
+    depends_on "xz" => :optional # Provides lzma compression.
+    
+    def install
+        ENV.deparallelize if MacOS.version >= :sierra
+        cd "src" do
+            ln_s "Make.inc/Makefile.inc.i686_mac_darwin10", "Makefile.inc"
+            # default CFLAGS:
+            # -O3 -Drestrict=__restrict -DCOMMON_FILE_COMPRESS_GZ -DCOMMON_PTHREAD
+            # -DCOMMON_PTHREAD_BARRIER -DCOMMON_RANDOM_FIXED_SEED -DCOMMON_TIMING_OLD
+            # -DSCOTCH_PTHREAD -DSCOTCH_RENAME
+            # MPI implementation is not threadsafe, do not use DSCOTCH_PTHREAD
+            
+            cflags   = %w[-O3 -fPIC -Drestrict=__restrict -DCOMMON_PTHREAD_BARRIER
+            -DCOMMON_PTHREAD
+            -DSCOTCH_CHECK_AUTO -DCOMMON_RANDOM_FIXED_SEED
+            -DCOMMON_TIMING_OLD -DSCOTCH_RENAME
+            -DCOMMON_FILE_COMPRESS_BZ2 -DCOMMON_FILE_COMPRESS_GZ]
+            ldflags  = %w[-lm -lz -lpthread -lbz2]
+            
+            cflags  += %w[-DCOMMON_FILE_COMPRESS_LZMA]   if build.with? "xz"
+            ldflags += %W[-L#{Formula["xz"].lib} -llzma] if build.with? "xz"
+            
+            make_args = ["CCS=#{ENV["CC"]}",
+            "CCP=mpicc",
+            "CCD=mpicc",
+            "RANLIB=echo",
+            "CFLAGS=#{cflags.join(" ")}",
+            "LDFLAGS=#{ldflags.join(" ")}"]
+            
+            if OS.mac?
+                make_args << "LIB=.dylib"
+                make_args << "AR=libtool"
+                arflags = ldflags.join(" ") + " -dynamic -install_name #{lib}/$(notdir $@) -undefined dynamic_lookup -o"
+                make_args << "ARFLAGS=#{arflags}"
+                else
+                make_args << "LIB=.so"
+                make_args << "ARCH=ar"
+                make_args << "ARCHFLAGS=-ruv"
+            end
+            
+            system "make", "scotch", "VERBOSE=ON", *make_args
+            system "make", "ptscotch", "VERBOSE=ON", *make_args
+            system "make", "install", "prefix=#{prefix}", *make_args
+            system "make", "check", "ptcheck", "EXECP=mpirun -np 2", *make_args if build.with? "test"
+        end
+        
+        # Install documentation + sample graphs and grids.
+        doc.install Dir["doc/*.pdf"]
+        pkgshare.install Dir["doc/*.f"], Dir["doc/*.txt"]
+        pkgshare.install "grf", "tgt"
+    end
+    
+    test do
+    mktemp do
+    system "echo cmplt 7 | #{bin}/gmap #{pkgshare}/grf/bump.grf.gz - bump.map"
+    system "#{bin}/gmk_m2 32 32 | #{bin}/gmap - #{pkgshare}/tgt/h8.tgt brol.map"
+    system "#{bin}/gout", "-Mn", "-Oi", "#{pkgshare}/grf/4elt.grf.gz", "#{pkgshare}/grf/4elt.xyz.gz", "-", "graph.iv"
+end
+end
+end

--- a/scotch5.rb
+++ b/scotch5.rb
@@ -1,0 +1,70 @@
+class Scotch5 < Formula
+  homepage "https://gforge.inria.fr/projects/scotch"
+  url "https://gforge.inria.fr/frs/download.php/28978"
+  version "5.1.12b"
+  sha256 "82654e63398529cd3bcc8eefdd51d3b3161c0429bb11770e31f8eb0c3790db6e"
+  revision 2
+
+  bottle :disable, "needs to be rebuilt with latest open-mpi"
+
+  keg_only "Conflicts with scotch (6.x)"
+
+  depends_on "open-mpi"
+
+  # bugs in makefile:
+  # - libptesmumps must be built before main_esmumps
+  # - install should also install the lib*esmumps.a libraries
+  patch :DATA
+
+  def install
+    cd "src" do
+      # Use mpicc to compile the parallelized version
+      make_args = ["CCS=#{ENV["CC"]}",
+                   "CCP=#{ENV["MPICC"]}",
+                   "CCD=#{ENV["MPICC"]}",
+                   "RANLIB=echo"]
+      if OS.mac?
+        ln_s "Make.inc/Makefile.inc.i686_mac_darwin8", "Makefile.inc"
+        make_args += ["LIB=.dylib",
+                      "AR=libtool",
+                      "ARFLAGS=-dynamic -install_name #{lib}/$(notdir $@) -undefined dynamic_lookup -o "]
+      else
+        ln_s "Make.inc/Makefile.inc.x86-64_pc_linux2", "Makefile.inc"
+        make_args += ["LIB=.so",
+                      "AR=$(CCS)",
+                      "ARFLAGS=-shared -Wl,-soname -Wl,#{lib}/$(notdir $@) -o "]
+      end
+      inreplace "Makefile.inc", "-O3", "-O3 -fPIC"
+
+      system "make", "scotch", *make_args
+      system "make", "ptscotch", *make_args
+      system "make", "install", "prefix=#{prefix}", *make_args
+    end
+  end
+end
+
+__END__
+diff -rupN scotch_5.1.12_esmumps/src/Makefile scotch_5.1.12_esmumps.patched/src/Makefile
+--- scotch_5.1.12_esmumps/src/Makefile	2011-02-12 12:06:58.000000000 +0100
++++ scotch_5.1.12_esmumps.patched/src/Makefile	2013-08-07 14:56:06.000000000 +0200
+@@ -105,6 +105,7 @@ install				:	required	$(bindir)	$(includ
+ 					-$(CP) -f ../bin/[agm]*$(EXE) $(bindir)
+ 					-$(CP) -f ../include/*scotch*.h $(includedir)
+ 					-$(CP) -f ../lib/*scotch*$(LIB) $(libdir)
++					-$(CP) -f ../lib/*esmumps*$(LIB) $(libdir)
+ 					-$(CP) -Rf ../man/* $(mandir)
+ 
+ clean				:	required
+diff -rupN scotch_5.1.12_esmumps/src/esmumps/Makefile scotch_5.1.12_esmumps.patched/src/esmumps/Makefile
+--- scotch_5.1.12_esmumps/src/esmumps/Makefile	2010-07-02 23:31:06.000000000 +0200
++++ scotch_5.1.12_esmumps.patched/src/esmumps/Makefile	2013-08-07 14:48:30.000000000 +0200
+@@ -59,7 +59,8 @@ scotch				:	clean
+ 
+ ptscotch			:	clean
+ 					$(MAKE) CFLAGS="$(CFLAGS) -DSCOTCH_PTSCOTCH" CC=$(CCP) SCOTCHLIB=ptscotch ESMUMPSLIB=ptesmumps	\
+-					libesmumps$(LIB)										\
++					libesmumps$(LIB)
++					$(MAKE) CFLAGS="$(CFLAGS) -DSCOTCH_PTSCOTCH" CC=$(CCP) SCOTCHLIB=ptscotch ESMUMPSLIB=ptesmumps	\
+ 					main_esmumps$(EXE)
+ 
+ install				:

--- a/scotch5.rb
+++ b/scotch5.rb
@@ -1,3 +1,27 @@
+# Script obtained from the https://github.com/Homebrew/homebrew-science repository
+
+'''
+Copyright 2009-2016 Homebrew contributors.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+ 1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+ 2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+'''
+
 class Scotch5 < Formula
   homepage "https://gforge.inria.fr/projects/scotch"
   url "https://gforge.inria.fr/frs/download.php/28978"

--- a/src/MPC.cpp
+++ b/src/MPC.cpp
@@ -42,7 +42,7 @@ class FG_eval {
 MPC::MPC() {}
 MPC::~MPC() {}
 
-vector<double> MPC::Solve(Eigen::VectorXd state, Eigen::VectorXd coeffs) {
+std::vector<double> MPC::Solve(Eigen::VectorXd state, Eigen::VectorXd coeffs) {
   bool ok = true;
   size_t i;
   typedef CPPAD_TESTVECTOR(double) Dvector;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,8 @@
 #include "Eigen-3.3/Eigen/QR"
 #include "MPC.h"
 
+using namespace std;
+
 // for convenience
 using json = nlohmann::json;
 


### PR DESCRIPTION
- Added Scotch.rb and Scotch5.rb files, possible missing dependencies required for ipopt installation on MacOSX HIgh Sierra 10.13.6

- Fixed compilation error (For example : No template named 'vector') required std inclusion